### PR TITLE
Skip some checks if we already point to the destination release

### DIFF
--- a/usr/lib/linuxmint/mintupgrade/apt_utils.py
+++ b/usr/lib/linuxmint/mintupgrade/apt_utils.py
@@ -1,7 +1,11 @@
 #!/usr/bin/python3
 import apt
 import apt_pkg
+import aptsources.sourceslist
 import subprocess
+
+from constants import *
+
 APT_GET = 'DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt-get'
 APT_QUIET = '-fyq -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-overwrite"'
 
@@ -66,6 +70,29 @@ def get_held_packages():
         if pkg._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
             held_packages.append(pkg)
     return (held_packages)
+
+# Returns True if and only if
+# APT points to the Mint and base destination codenames
+def apt_points_to_destination():
+    apt_pkg.init_config()
+    sources = aptsources.sourceslist.SourcesList()
+    mint_points_to_dest = False
+    base_points_to_dest = False
+    for source in sources:
+        if source.disabled:
+            # commented out repos
+            continue
+        if source.uri == "":
+            # repos file entries themselves
+            continue
+        if DESTINATION_CODENAME in source.dist:
+            mint_points_to_dest = True
+        elif DESTINATION_BASE_CODENAME in source.dist:
+            base_points_to_dest = True
+    if mint_points_to_dest and base_points_to_dest:
+        return True
+    else:
+        return False
 
 if __name__ == "__main__":
     # orphans, foreign = get_foreign_packages()

--- a/usr/lib/linuxmint/mintupgrade/checks.py
+++ b/usr/lib/linuxmint/mintupgrade/checks.py
@@ -232,15 +232,7 @@ class APTCacheCheck(Check):
             self.message = _("Some of your packages are broken. Run 'apt install -f' to fix the issue.")
             return
 
-        points_to_destination = False
-        if os.path.exists("/etc/apt/sources.list.d/official-package-repositories.list"):
-            with open("/etc/apt/sources.list.d/official-package-repositories.list") as sources:
-                for line in sources:
-                    if DESTINATION_CODENAME in line:
-                        points_to_destination = True
-                        break
-
-        if not points_to_destination:
+        if not apt_points_to_destination():
             # Check updates
             if self.get_setting("check-updates"):
                 for pkg in CHECK_UP_TO_DATE:

--- a/usr/lib/linuxmint/mintupgrade/mintupgrade.py
+++ b/usr/lib/linuxmint/mintupgrade/mintupgrade.py
@@ -19,6 +19,7 @@ from gi.repository import Gtk, Gdk, Gio, XApp
 from common import *
 from constants import *
 from checks import *
+from apt_utils import *
 
 setproctitle.setproctitle("mintupgrade")
 
@@ -189,18 +190,21 @@ class MainWindow():
 
     def letsgo(self, button):
         self.checks = []
+        skip = apt_points_to_destination()
         info = ShowInfoCheck(_("Phase 1: Preparation"), callback=self.process_check_result)
         info.icon_name = "dialog-info"
         info.message = _("A series of tests will now be performed to prepare the computer for the upgrade.")
         self.checks.append(info)
         self.checks.append(VersionCheck(callback=self.process_check_result))
         self.checks.append(PowerCheck(callback=self.process_check_result))
-        self.checks.append(APTCacheCheck(self.window, callback=self.process_check_result))
+        if not skip:
+            self.checks.append(APTCacheCheck(self.window, callback=self.process_check_result))
         self.checks.append(TimeshiftCheck(callback=self.process_check_result))
         self.checks.append(APTHeldCheck(callback=self.process_check_result))
         self.checks.append(APTRepoCheck(callback=self.process_check_result))
-        self.checks.append(APTForeignCheck(callback=self.process_check_result))
-        self.checks.append(APTOrphanCheck(callback=self.process_check_result))
+        if not skip:
+            self.checks.append(APTForeignCheck(callback=self.process_check_result))
+            self.checks.append(APTOrphanCheck(callback=self.process_check_result))
         info = ShowInfoCheck(_("Phase 2: Simulation and download"), callback=self.process_check_result)
         info.icon_name = "dialog-info"
         info.message = _("Your package repositories will now point towards the new release.")


### PR DESCRIPTION
The following scenario created an issue:

- perform all steps from phase 1 and 2
- exit the application
- rerun the application

The first time the upgrader is run it makes the OS point to the new
release's repositories, but because we exited the app, the cache
isn't upgraded.

Running apt orphan checks again creates mayhem and wants to remove
packages.

This commit checks if we're pointing to the new release. If we are,
we skip these checks in phase 1.