### PR TITLE
Fix minor grammar issue across 44 files

### DIFF
--- a/mintupgrade.pot
+++ b/mintupgrade.pot
@@ -525,7 +525,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ar.po
+++ b/po/mintupgrade-ar.po
@@ -527,7 +527,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-be.po
+++ b/po/mintupgrade-be.po
@@ -545,7 +545,7 @@ msgstr "Патрабаванні"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ca.po
+++ b/po/mintupgrade-ca.po
@@ -561,7 +561,7 @@ msgstr "Requeriments"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-cs.po
+++ b/po/mintupgrade-cs.po
@@ -538,7 +538,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-cy.po
+++ b/po/mintupgrade-cy.po
@@ -568,7 +568,7 @@ msgstr "Gofynion"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-da.po
+++ b/po/mintupgrade-da.po
@@ -554,7 +554,7 @@ msgstr "Krav"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-de.po
+++ b/po/mintupgrade-de.po
@@ -575,7 +575,7 @@ msgstr "Voraussetzungen"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-el.po
+++ b/po/mintupgrade-el.po
@@ -575,7 +575,7 @@ msgstr "Απαιτήσεις"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-en_GB.po
+++ b/po/mintupgrade-en_GB.po
@@ -535,7 +535,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-eo.po
+++ b/po/mintupgrade-eo.po
@@ -555,7 +555,7 @@ msgstr "Postuloj"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-es.po
+++ b/po/mintupgrade-es.po
@@ -567,7 +567,7 @@ msgstr "Requisitos"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-et.po
+++ b/po/mintupgrade-et.po
@@ -560,7 +560,7 @@ msgstr "Nõuded"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-eu.po
+++ b/po/mintupgrade-eu.po
@@ -563,7 +563,7 @@ msgstr "Eskakizunak"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-fi.po
+++ b/po/mintupgrade-fi.po
@@ -556,7 +556,7 @@ msgstr "Vaatimukset"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-fr.po
+++ b/po/mintupgrade-fr.po
@@ -578,7 +578,7 @@ msgstr "Conditions"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-fr_CA.po
+++ b/po/mintupgrade-fr_CA.po
@@ -575,7 +575,7 @@ msgstr "Conditions"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-he.po
+++ b/po/mintupgrade-he.po
@@ -537,7 +537,7 @@ msgstr "דרישות"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-hi.po
+++ b/po/mintupgrade-hi.po
@@ -568,7 +568,7 @@ msgstr "आवश्यकताएँ"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-hr.po
+++ b/po/mintupgrade-hr.po
@@ -558,7 +558,7 @@ msgstr "Zahtjevi"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-hu.po
+++ b/po/mintupgrade-hu.po
@@ -582,7 +582,7 @@ msgstr "Követelmények"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ia.po
+++ b/po/mintupgrade-ia.po
@@ -529,7 +529,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-id.po
+++ b/po/mintupgrade-id.po
@@ -527,7 +527,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-is.po
+++ b/po/mintupgrade-is.po
@@ -566,7 +566,7 @@ msgstr "Kerfiskröfur"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-it.po
+++ b/po/mintupgrade-it.po
@@ -570,7 +570,7 @@ msgstr "Requisiti"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ja.po
+++ b/po/mintupgrade-ja.po
@@ -527,7 +527,7 @@ msgstr "要件"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-kab.po
+++ b/po/mintupgrade-kab.po
@@ -529,7 +529,7 @@ msgstr "Ayen yettwasran"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ko.po
+++ b/po/mintupgrade-ko.po
@@ -527,7 +527,7 @@ msgstr "요구사항"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-la.po
+++ b/po/mintupgrade-la.po
@@ -528,7 +528,7 @@ msgstr "Necessaria"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-nl.po
+++ b/po/mintupgrade-nl.po
@@ -571,7 +571,7 @@ msgstr "Vereisten"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-oc.po
+++ b/po/mintupgrade-oc.po
@@ -533,7 +533,7 @@ msgstr "Prerequesits"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-pl.po
+++ b/po/mintupgrade-pl.po
@@ -559,7 +559,7 @@ msgstr "Wymagania"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-pt.po
+++ b/po/mintupgrade-pt.po
@@ -570,7 +570,7 @@ msgstr "Requisitos"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-pt_BR.po
+++ b/po/mintupgrade-pt_BR.po
@@ -563,7 +563,7 @@ msgstr "Requisitos"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ro.po
+++ b/po/mintupgrade-ro.po
@@ -529,7 +529,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-ru.po
+++ b/po/mintupgrade-ru.po
@@ -558,7 +558,7 @@ msgstr "Требования"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-sk.po
+++ b/po/mintupgrade-sk.po
@@ -555,7 +555,7 @@ msgstr "Požiadavky"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-sl.po
+++ b/po/mintupgrade-sl.po
@@ -557,7 +557,7 @@ msgstr "Zahteve"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-sv.po
+++ b/po/mintupgrade-sv.po
@@ -556,7 +556,7 @@ msgstr "Krav"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-tr.po
+++ b/po/mintupgrade-tr.po
@@ -562,7 +562,7 @@ msgstr "Gereklilikler"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-uk.po
+++ b/po/mintupgrade-uk.po
@@ -527,7 +527,7 @@ msgstr ""
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-uz.po
+++ b/po/mintupgrade-uz.po
@@ -564,7 +564,7 @@ msgstr "Talablar"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/po/mintupgrade-zh_CN.po
+++ b/po/mintupgrade-zh_CN.po
@@ -527,7 +527,7 @@ msgstr "依赖"
 
 #: usr/share/linuxmint/mintupgrade/mintupgrade.ui.h:18
 msgid ""
-"Orphan packages are packages who are not present in the repositories. They "
+"Orphan packages are packages that are not present in the repositories. They "
 "get removed during the upgrade. If you want to keep some of them, add them "
 "to the list below:"
 msgstr ""

--- a/usr/share/linuxmint/mintupgrade/mintupgrade.ui
+++ b/usr/share/linuxmint/mintupgrade/mintupgrade.ui
@@ -678,7 +678,7 @@
                                         <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="margin_bottom">12</property>
-                                        <property name="label" translatable="yes">Orphan packages are packages who are not present in the repositories. They get removed during the upgrade. If you want to keep some of them, add them to the list below:</property>
+                                        <property name="label" translatable="yes">Orphan packages are packages that are not present in the repositories. They get removed during the upgrade. If you want to keep some of them, add them to the list below:</property>
                                         <property name="wrap">True</property>
                                         <property name="xalign">0</property>
                                       </object>


### PR DESCRIPTION
Fixes grammatical issue by replacing "who" with "that" in the following sentence: "Orphan packages are packages who are not present in the repositories."

"Who" refers exclusively to a person or persons (see https://en.wiktionary.org/wiki/who#English); "that" is the appropriate pronoun.

Changes via:
`grep -r 'packages who' . | cut -d: -f1 | xargs -I {} sed -i 's/packages who/packages that/' {}`