### PR TITLE
Fix for external apt repos with mint codenames

### DIFF
--- a/usr/lib/linuxmint/mintupgrade/checks.py
+++ b/usr/lib/linuxmint/mintupgrade/checks.py
@@ -368,6 +368,11 @@ class APTRepoCheck(Check):
                 continue
             timestamp = self.get_url_last_modified("%s/db/version" % repo.uri)
             if timestamp == None:
+                # Retry with standard repo layout (for repos which use the mint codenames)
+                new_dist = repo.dist.replace(ORIGIN_CODENAME, DESTINATION_CODENAME)
+                url = "%s/dists/%s/Release" % (repo.uri, new_dist)                
+                timestamp = self.get_url_last_modified(url)           
+            if timestamp == None:
                 problems.append(_("%s is unreachable") % repo.uri)
             elif mint_age > 2:
                 date = datetime.datetime.fromtimestamp(timestamp)


### PR DESCRIPTION
While running mintupgrade I encountered the following error:
"http://deb.librewolf.net is unreachable"

While debugging I saw that mintupgrade is querying the following:
http://deb.librewolf.net/db/version

The librewolf repo uses the standard dist codenames for mint (i.e. una, vanessa, etc.).
The correct url is:
http://deb.librewolf.net/dists/vanessa/Release

This patch retries the url with the standard layout for non-official mint urls.