### PR TITLE
Rewrite https keyword used by apt-cacher-ng

### DIFF
--- a/usr/lib/linuxmint/mintupgrade/checks.py
+++ b/usr/lib/linuxmint/mintupgrade/checks.py
@@ -400,6 +400,9 @@ class APTRepoCheck(Check):
 
     def get_url_last_modified(self, url):
         try:
+            if (url.startswith(APT_CACHER_NG_HTTPS)):
+                url = 'https://' + url[len(APT_CACHER_NG_HTTPS):]
+
             c = pycurl.Curl()
             c.setopt(pycurl.URL, url)
             c.setopt(pycurl.CONNECTTIMEOUT, 30)

--- a/usr/lib/linuxmint/mintupgrade/constants.py
+++ b/usr/lib/linuxmint/mintupgrade/constants.py
@@ -11,3 +11,5 @@ else:
 
 BACKUP_FSTAB = os.path.expanduser("~/.fstab.bk")
 BACKUP_LOCALEDEF = os.path.expanduser("~/.localedef.bk")
+
+APT_CACHER_NG_HTTPS = 'http://HTTPS///'


### PR DESCRIPTION
apt-cacher-ng use a special keyword for apt urls with https to allow caching.

This patch rewrites this url while using curl to check the last modified date of an apt repo:
http://HTTPS/// -> https://