### PR TITLE
Correct a typo in `po/mintupgrade-fr{, _CA}.po`

### DIFF
--- a/po/mintupgrade-fr.po
+++ b/po/mintupgrade-fr.po
@@ -38,7 +38,7 @@ msgstr "Relancez l'outil de mise à niveau pour de migrer dépôts à nouveau."
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:146
 msgid "Linux Mint version"
-msgstr "Version de Linux MInt"
+msgstr "Version de Linux Mint"
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:146
 msgid "Checking your version of Linux Mint..."

--- a/po/mintupgrade-fr_CA.po
+++ b/po/mintupgrade-fr_CA.po
@@ -39,7 +39,7 @@ msgstr ""
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:146
 msgid "Linux Mint version"
-msgstr "Version de Linux MInt"
+msgstr "Version de Linux Mint"
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:146
 msgid "Checking your version of Linux Mint..."


### PR DESCRIPTION
I verified the exhaustiveness of my typo correction using:
```
grep -r 'MInt'
```