### PR TITLE
Cleanup: Remove all unused dependencies

### DIFF
--- a/usr/bin/mintupgrade-inhibit-power
+++ b/usr/bin/mintupgrade-inhibit-power
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import sys
-import psutil
 import time
 import os
 import subprocess

--- a/usr/lib/linuxmint/mintupgrade/checks.py
+++ b/usr/lib/linuxmint/mintupgrade/checks.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
-import gi
-import threading
-from gi.repository import GObject, Gio, GLib
+from gi.repository import Gio, GLib
 import time
 import os
 import datetime

--- a/usr/lib/linuxmint/mintupgrade/common.py
+++ b/usr/lib/linuxmint/mintupgrade/common.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-import gi
 import threading
 from gi.repository import GObject
 

--- a/usr/lib/linuxmint/mintupgrade/mintupgrade.py
+++ b/usr/lib/linuxmint/mintupgrade/mintupgrade.py
@@ -4,10 +4,7 @@ import gi
 import locale
 import os
 import setproctitle
-import subprocess
 import warnings
-import sys
-import traceback
 
 # Suppress GTK deprecation warnings
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
Changes:
- `psutil` from `mintupgrade-inhibit-power.py`
- `gi` and `threading` from `checks.py`
- `gi` from `common.py`
- `sys`, `subprocess` and `traceback` from `mintupgrade.py`