### PR TITLE
Fixes related to pre-upgrade orphan check.

### DIFF
--- a/usr/lib/linuxmint/mintupgrade/checks.py
+++ b/usr/lib/linuxmint/mintupgrade/checks.py
@@ -521,6 +521,8 @@ class APTOrphanCheck(Check):
         self.pre_upgrade_orphans = pre_upgrade_orphans
 
     def do_run(self):
+        self.pre_upgrade_orphans.clear()
+
         orphans, foreigns = get_foreign_packages(find_orphans=True, find_downgradable_packages=False)
         if len(orphans) > 0:
             for orphan in orphans:
@@ -532,6 +534,8 @@ class APTOrphanCheck(Check):
                 if pkg.name.startswith("linux-headers-"):
                     continue
                 self.pre_upgrade_orphans.append(pkg.name)
+
+        self.info = []
 
         if len(self.pre_upgrade_orphans) > 0:
             self.result = RESULT_INFO
@@ -547,6 +551,8 @@ class APTOrphanCheck(Check):
             self.info.append(_("If you decide to uninstall some of these packages press 'Check again' after their removal."))
             self.info.append(_("Press 'OK' to continue with the upgrade."))
             return
+
+        self.result = RESULT_SUCCESS
 
 # Remove newly orphaned pkgs (post upgrade)
 class APTRemoveOrphansCheck(Check):

--- a/usr/lib/linuxmint/mintupgrade/mintupgrade.py
+++ b/usr/lib/linuxmint/mintupgrade/mintupgrade.py
@@ -194,7 +194,7 @@ class MainWindow():
             print("Check succeeded: ", check.title)
             if check in self.checks:
                 self.checks.remove(check)
-                self.run_next_check()
+            self.run_next_check()
         elif check.result == RESULT_EXCEPTION:
             self.builder.get_object("upgrade_stack").set_visible_child_name("page_exception")
             self.builder.get_object("label_stacktrace").set_text(check.message)


### PR DESCRIPTION
checks.py:
- Clear pre_upgrade_orphans when re-running the check.
- When running the check, always reset self.info, not just if
  there are packages to add to it.
- Set RESULT_SUCCESS if the check passes without any orphans
  found - otherwise this may remain RESULT_INFO when running the
  check more than once.

mintupgrade.py:
- Always run_next_check() on success, not just if check is in
  self.checks. Checks with RESULT_INFO are removed after their
  first run.