### PR TITLE
Fixed confusing terms in UI Spanish translation

### DIFF
--- a/po/mintupgrade-es.po
+++ b/po/mintupgrade-es.po
@@ -93,7 +93,7 @@ msgstr ""
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:198
 msgid "Press 'Fix' to perform a system snapshot."
-msgstr "Pulse 'Reparar' para realizar una instantánea del sistema."
+msgstr "Pulse 'Corregir' para realizar una instantánea del sistema."
 
 #: usr/lib/linuxmint/mintupgrade/checks.py:214
 msgid "APT cache"


### PR DESCRIPTION
Fixed a mismatch between terms. In the Spanish text the UI prompts "Pulse 'Reparar' (fix) para realizar..." However the button in the UI has the text "Corregir" Now the text and the button has the same text: 